### PR TITLE
Allow for specifying whether to select the search input content when activated

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -18,11 +18,18 @@ interface SearchConfig {
   /// Whether to position the search panel at the top of the editor
   /// (the default is at the bottom).
   top?: boolean
+
+  /// Whether to select the content of the search panel when activated
+  /// (the default is false)
+  select?: boolean
 }
 
 const searchConfigFacet = Facet.define<SearchConfig, Required<SearchConfig>>({
   combine(configs) {
-    return {top: configs.some(c => c.top)}
+    return {
+      top: configs.some(c => c.top),
+      select: configs.some(c => c.select),
+    }
   }
 })
 
@@ -363,7 +370,11 @@ export const openSearchPanel: Command = view => {
   if (state && state.panel) {
     let panel = getPanel(view, createSearchPanel)
     if (!panel) return false
-    ;(panel.dom.querySelector("[name=search]") as HTMLInputElement).focus()
+    let searchInput = panel.dom.querySelector("[name=search]") as HTMLInputElement
+    searchInput.focus()
+    if (view.state.facet(searchConfigFacet).select === true) {
+      searchInput.select()
+    }
   } else {
     view.dispatch({effects: [
       togglePanel.of(true),


### PR DESCRIPTION
Problem: When I use the search panel multiple times, previous search input isn't cleared on subsequent searches.

This patch addresses this problem by adding a "select" option to the search config.

Steps to demo intended behavior

1) Hit Cmd+f
2) Type in "foo". Editor correctly finds "foo" 
3) Hit escape
4) Hit Cmd+f
5) Type in "bar". Editor finds "foobar" instead of my expected "bar".

Adding the option "select" means that the previous content "foo" is selected by default when focusing on the search input with Cmd+f, so typing "bar" overrides the previous input.