### PR TITLE
Allow for specifying whether to select the search input content when activated

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -363,7 +363,9 @@ export const openSearchPanel: Command = view => {
   if (state && state.panel) {
     let panel = getPanel(view, createSearchPanel)
     if (!panel) return false
-    ;(panel.dom.querySelector("[name=search]") as HTMLInputElement).focus()
+    let searchInput = panel.dom.querySelector("[name=search]") as HTMLInputElement
+    searchInput.focus()
+    searchInput.select()
   } else {
     view.dispatch({effects: [
       togglePanel.of(true),

--- a/src/search.ts
+++ b/src/search.ts
@@ -18,18 +18,11 @@ interface SearchConfig {
   /// Whether to position the search panel at the top of the editor
   /// (the default is at the bottom).
   top?: boolean
-
-  /// Whether to select the content of the search panel when activated
-  /// (the default is false)
-  select?: boolean
 }
 
 const searchConfigFacet = Facet.define<SearchConfig, Required<SearchConfig>>({
   combine(configs) {
-    return {
-      top: configs.some(c => c.top),
-      select: configs.some(c => c.select),
-    }
+    return {top: configs.some(c => c.top)}
   }
 })
 
@@ -370,11 +363,7 @@ export const openSearchPanel: Command = view => {
   if (state && state.panel) {
     let panel = getPanel(view, createSearchPanel)
     if (!panel) return false
-    let searchInput = panel.dom.querySelector("[name=search]") as HTMLInputElement
-    searchInput.focus()
-    if (view.state.facet(searchConfigFacet).select === true) {
-      searchInput.select()
-    }
+    ;(panel.dom.querySelector("[name=search]") as HTMLInputElement).focus()
   } else {
     view.dispatch({effects: [
       togglePanel.of(true),

--- a/src/search.ts
+++ b/src/search.ts
@@ -18,11 +18,18 @@ interface SearchConfig {
   /// Whether to position the search panel at the top of the editor
   /// (the default is at the bottom).
   top?: boolean
+
+  /// Whether to select the content of the search panel when activated
+  /// (the default is false)
+  select?: boolean
 }
 
 const searchConfigFacet = Facet.define<SearchConfig, Required<SearchConfig>>({
   combine(configs) {
-    return {top: configs.some(c => c.top)}
+    return {
+      top: configs.some(c => c.top),
+      select: configs.some(c => c.select),
+    }
   }
 })
 
@@ -363,7 +370,11 @@ export const openSearchPanel: Command = view => {
   if (state && state.panel) {
     let panel = getPanel(view, createSearchPanel)
     if (!panel) return false
-    ;(panel.dom.querySelector("[name=search]") as HTMLInputElement).focus()
+    let searchInput = panel.dom.querySelector("[name=search]") as HTMLInputElement
+    searchInput.focus()
+    if (view.state.facet(searchConfigFacet).select === true) {
+      searchInput.select()
+    }
   } else {
     view.dispatch({effects: [
       togglePanel.of(true),


### PR DESCRIPTION
Prior to this change, when I used the search panel multiple times in the same document the previous search input wouldn't be cleared when I hit Cmd+F.

This patch addresses this problem by adding a "select" option to the search config.

Steps to demo intended behavior

- Hit Cmd+f
- Type in "foo". Editor correctly finds "foo"
- Hit escape
- Hit Cmd+f
- Type in "bar". Editor finds "foobar" instead of my expected "bar".

Adding the option "select" means that the previous content "foo" is selected by default when focusing on the search input with Cmd+f, so typing "bar" overrides the previous input.