### PR TITLE
Add a highlightSelectionMatches option to only match whole words

### DIFF
--- a/src/selection-match.ts
+++ b/src/selection-match.ts
@@ -74,12 +74,11 @@ const matchHighlighter = ViewPlugin.fromClass(class {
     let conf = view.state.facet(highlightConfig)
     let {state} = view, sel = state.selection
     if (sel.ranges.length > 1) return Decoration.none
-    let range = sel.main, query, check = null, empty = false
+    let range = sel.main, query, check = null
     if (range.empty) {
       if (!conf.highlightWordAroundCursor) return Decoration.none
       let word = state.wordAt(range.head)
       if (!word) return Decoration.none
-      empty = true
       check = state.charCategorizer(range.head)
       query = state.sliceDoc(word.from, word.to)
     } else {
@@ -102,7 +101,7 @@ const matchHighlighter = ViewPlugin.fromClass(class {
       while (!cursor.next().done) {
         let {from, to} = cursor.value
         if (!check || insideWordBoundaries(check, state, from, to)) {
-          if (empty && from <= range.from && to >= range.to)
+          if (range.empty && from <= range.from && to >= range.to)
             deco.push(mainMatchDeco.range(from, to))
           else if (from >= range.to || to <= range.from)
             deco.push(matchDeco.range(from, to))

--- a/src/selection-match.ts
+++ b/src/selection-match.ts
@@ -86,7 +86,7 @@ const matchHighlighter = ViewPlugin.fromClass(class {
       let len = range.to - range.from
       if (len < conf.minSelectionLength || len > 200) return Decoration.none
       if (conf.wholeWords) {
-        query = state.sliceDoc(range.from, range.to)
+        query = state.sliceDoc(range.from, range.to) // TODO: allow and include leading/trailing space?
         if (!query) return Decoration.none
         check = state.charCategorizer(range.head)
         if (!(insideWordBoundaries(check, state, range.from, range.to)

--- a/src/selection-match.ts
+++ b/src/selection-match.ts
@@ -86,7 +86,6 @@ const matchHighlighter = ViewPlugin.fromClass(class {
       if (len < conf.minSelectionLength || len > 200) return Decoration.none
       if (conf.wholeWords) {
         query = state.sliceDoc(range.from, range.to) // TODO: allow and include leading/trailing space?
-        if (!query) return Decoration.none
         check = state.charCategorizer(range.head)
         if (!(insideWordBoundaries(check, state, range.from, range.to)
             && insideWord(check, state, range.from, range.to))) return Decoration.none


### PR DESCRIPTION
To reduce the amount of noise when making selections while editing prose (e.g. Markdown), it would be nice to have an option to only match whole words.

This adds a new `wholeWords` boolean option to the `highlightSelectionMatches` extension config. When this option is set, selection matches will only be shown when a) the current selection is a whole word and b) the match is a whole word.

https://user-images.githubusercontent.com/14294/155411159-e84b9e54-4367-482e-90b4-d0e6cc46f4f1.mov


