### PR TITLE
Add numMatches method to SearchQuery

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -104,6 +104,13 @@ export class SearchQuery {
       this.caseSensitive == other.caseSensitive && this.regexp == other.regexp
   }
 
+  /// Returns the number of matches in the given document. 
+  numMatches(doc: Text, limit: number = 1000) {
+    let query = this.create()
+    let matches = query.matchAll(doc, limit)
+    return matches ? matches.length : 0
+  }
+
   /// @internal
   create(): QueryType {
     return this.regexp ? new RegExpQuery(this) : new StringQuery(this)


### PR DESCRIPTION
Fixes the issue described here: https://github.com/codemirror/codemirror.next/issues/727

Although calculating the total number of matches for a given search query can be expensive and is calculated lazily, I believe it can be useful to expose this functionality for certain product use cases (for example, displaying the number of matches to the user in a custom search panel).

Let me know if this sounds reasonable and like something you would accept, otherwise I can close!