### PR TITLE
Add config option for literal search queries

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -84,6 +84,8 @@ export class SearchQuery {
     search: string,
     /// Controls whether the search should be case-sensitive.
     caseSensitive?: boolean,
+    /// When true, interpret the search string as a literal sequence of characters.
+    literal?: boolean,
     /// When true, interpret the search string as a regular expression.
     regexp?: boolean,
     /// The replace text.
@@ -94,7 +96,7 @@ export class SearchQuery {
     this.regexp = !!config.regexp
     this.replace = config.replace || ""
     this.valid = !!this.search && (!this.regexp || validRegExp(this.search))
-    this.unquoted = this.search.replace(/\\([nrt\\])/g,
+    this.unquoted = config.literal ? this.search : this.search.replace(/\\([nrt\\])/g,
                                         (_, ch) => ch == "n" ? "\n" : ch == "r" ? "\r" : ch == "t" ? "\t" : "\\")
   }
 


### PR DESCRIPTION
As it's quite common when writing LaTeX to have text which contains `\t` (e.g. `\textbf`), `\n` (e.g. `\newpage`) or `\r` (e.g. `\rightarrow`), it would be useful if a search query could have an option to disable the automatic conversion of these characters.

The config option added in this branch seems to have the desired effect, but the name of the config option is debatable (it could be `exact`, perhaps, or something else).

It's still possible to match newlines (for example) by entering `\n`, but only in regex mode.