### PR TITLE
Add `literal` option to search extension config

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -21,6 +21,9 @@ interface SearchConfig {
   /// panel is activated (defaults to false).
   caseSensitive?: boolean
 
+  // Whether to treat string searches literally by default (defaults to false).
+  literal?: boolean
+
   /// Can be used to override the way the search panel is implemented.
   /// Should create a [Panel](#view.Panel) that contains a form
   /// which lets the user:
@@ -40,6 +43,7 @@ const searchConfigFacet: Facet<SearchConfig, Required<SearchConfig>> = Facet.def
     return {
       top: configs.reduce((val, conf) => val ?? conf.top, undefined as boolean | undefined) || false,
       caseSensitive: configs.reduce((val, conf) => val ?? conf.caseSensitive, undefined as boolean | undefined) || false,
+      literal: configs.reduce((val, conf) => val ?? conf.literal, undefined as boolean | undefined) || false,
       createPanel: configs.find(c => c.createPanel)?.createPanel || (view => new SearchPanel(view))
     }
   }
@@ -59,6 +63,10 @@ export class SearchQuery {
   readonly search: string
   /// Indicates whether the search is case-sensitive.
   readonly caseSensitive: boolean
+  /// By default, string search will replace `\n`, `\r`, and `\t` in
+  /// the query with newline, return, and tab characters. When this
+  /// is set to true, that behavior is disabled.
+  readonly literal: boolean
   /// Then true, the search string is interpreted as a regular
   /// expression.
   readonly regexp: boolean
@@ -89,10 +97,11 @@ export class SearchQuery {
   }) {
     this.search = config.search
     this.caseSensitive = !!config.caseSensitive
+    this.literal = !!config.literal
     this.regexp = !!config.regexp
     this.replace = config.replace || ""
     this.valid = !!this.search && (!this.regexp || validRegExp(this.search))
-    this.unquoted = config.literal ? this.search : this.search.replace(/\\([nrt\\])/g,
+    this.unquoted = this.literal ? this.search : this.search.replace(/\\([nrt\\])/g,
                                         (_, ch) => ch == "n" ? "\n" : ch == "r" ? "\r" : ch == "t" ? "\t" : "\\")
   }
 
@@ -427,8 +436,13 @@ function createSearchPanel(view: EditorView) {
 function defaultQuery(state: EditorState, fallback?: SearchQuery) {
   let sel = state.selection.main
   let selText = sel.empty || sel.to > sel.from + 100 ? "" : state.sliceDoc(sel.from, sel.to)
-  let caseSensitive = fallback?.caseSensitive ?? state.facet(searchConfigFacet).caseSensitive
-  return fallback && !selText ? fallback : new SearchQuery({search: selText.replace(/\n/g, "\\n"), caseSensitive})
+  if (fallback && !selText) return fallback
+  let config = state.facet(searchConfigFacet)
+  return new SearchQuery({
+    search: (fallback?.literal ?? config.literal) ? selText : selText.replace(/\n/g, "\\n"),
+    caseSensitive: fallback?.caseSensitive ?? config.caseSensitive,
+    literal: fallback?.literal ?? config.literal,
+  })
 }
 
 /// Make sure the search panel is open and focused.


### PR DESCRIPTION
Following #12, which added a `literal` option to the `SearchQuery` config, this adds a `literal` option to the `search` extension config, which is used when building the default query from any selected text.

Most of the changes are copied from the handling of the `caseSensitive` option, which behaves in a similar way.