### PR TITLE
Add "whole word" option to search/query config

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -21,7 +21,7 @@ interface SearchConfig {
   /// Whether to enable case sensitivity by default when the search
   /// panel is activated (defaults to false).
   caseSensitive?: boolean
-  
+
   // Whether to treat string searches literally by default (defaults to false).
   literal?: boolean
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -8,9 +8,10 @@ import {SearchCursor} from "./cursor"
 import {RegExpCursor, validRegExp} from "./regexp"
 import {gotoLine} from "./goto-line"
 import {selectNextOccurrence} from "./selection-match"
+import {isWholeWord} from "./word"
 
 export {highlightSelectionMatches} from "./selection-match"
-export {SearchCursor, RegExpCursor, gotoLine, selectNextOccurrence}
+export {SearchCursor, RegExpCursor, gotoLine, isWholeWord, selectNextOccurrence}
 
 interface SearchConfig {
   /// Whether to position the search panel at the top of the editor
@@ -20,6 +21,10 @@ interface SearchConfig {
   /// Whether to enable case sensitivity by default when the search
   /// panel is activated (defaults to false).
   caseSensitive?: boolean
+
+  /// Whether to enable whole word search by default when the search
+  /// panel is activated (defaults to false).
+  wholeWord?: boolean
 
   /// Can be used to override the way the search panel is implemented.
   /// Should create a [Panel](#view.Panel) that contains a form
@@ -43,6 +48,7 @@ const searchConfigFacet: Facet<SearchConfig, Required<SearchConfig>> = Facet.def
     return {
       top: configs.reduce((val, conf) => val ?? conf.top, undefined as boolean | undefined) || false,
       caseSensitive: configs.reduce((val, conf) => val ?? conf.caseSensitive, undefined as boolean | undefined) || false,
+      wholeWord: configs.reduce((val, conf) => val ?? conf.wholeWord, undefined as boolean | undefined) || false,
       createPanel: configs.find(c => c.createPanel)?.createPanel || (view => new SearchPanel(view))
     }
   }
@@ -65,6 +71,8 @@ export class SearchQuery {
   /// Then true, the search string is interpreted as a regular
   /// expression.
   readonly regexp: boolean
+  /// Whether the search query should only match whole words.
+  readonly wholeWord: boolean
   /// The replace text, or the empty string if no replace text has
   /// been given.
   readonly replace: string
@@ -87,12 +95,15 @@ export class SearchQuery {
     literal?: boolean,
     /// When true, interpret the search string as a regular expression.
     regexp?: boolean,
+    /// Whether the search query should only match whole words (when regexp is not enabled).
+    wholeWord?: boolean,
     /// The replace text.
     replace?: string,
   }) {
     this.search = config.search
     this.caseSensitive = !!config.caseSensitive
     this.regexp = !!config.regexp
+    this.wholeWord = !!config.wholeWord && !config.regexp
     this.replace = config.replace || ""
     this.valid = !!this.search && (!this.regexp || validRegExp(this.search))
     this.unquoted = config.literal ? this.search : this.search.replace(/\\([nrt\\])/g,
@@ -122,15 +133,15 @@ type SearchResult = typeof SearchCursor.prototype.value
 abstract class QueryType<Result extends SearchResult = SearchResult> {
   constructor(readonly spec: SearchQuery) {}
 
-  abstract nextMatch(doc: Text, curFrom: number, curTo: number): Result | null
+  abstract nextMatch(state: EditorState, curFrom: number, curTo: number): Result | null
 
-  abstract prevMatch(doc: Text, curFrom: number, curTo: number): Result | null
+  abstract prevMatch(state: EditorState, curFrom: number, curTo: number): Result | null
 
   abstract getReplacement(result: Result): string
 
-  abstract matchAll(doc: Text, limit: number): readonly Result[] | null
+  abstract matchAll(state: EditorState, limit: number): readonly Result[] | null
 
-  abstract highlight(doc: Text, from: number, to: number, add: (from: number, to: number) => void): void
+  abstract highlight(state: EditorState, from: number, to: number, add: (from: number, to: number) => void): void
 }
 
 const enum FindPrev { ChunkSize = 10000 }
@@ -139,50 +150,82 @@ function stringCursor(spec: SearchQuery, doc: Text, from: number, to: number) {
   return new SearchCursor(doc, spec.unquoted, from, to, spec.caseSensitive ? undefined : x => x.toLowerCase())
 }
 
+export const isValidMatch = (
+    query: SearchQuery,
+    state: EditorState,
+    match: { from: number; to: number }
+): boolean => {
+  if (query.wholeWord) {
+    const check = state.charCategorizer(match.from)
+    if (!isWholeWord(check, state, match.from, match.to)) {
+      return false
+    }
+  }
+
+  return true
+}
+
 class StringQuery extends QueryType<SearchResult> {
   constructor(spec: SearchQuery) {
     super(spec)
   }
 
-  nextMatch(doc: Text, curFrom: number, curTo: number) {
-    let cursor = stringCursor(this.spec, doc, curTo, doc.length).nextOverlapping()
-    if (cursor.done) cursor = stringCursor(this.spec, doc, 0, curFrom).nextOverlapping()
+  nextMatch(state: EditorState, curFrom: number, curTo: number): SearchResult | null {
+    let cursor = stringCursor(this.spec, state.doc, curTo, state.doc.length)
+
+    do {
+      cursor.nextOverlapping()
+    } while (!cursor.done && !isValidMatch(this.spec, state, cursor.value))
+
+    if (cursor.done && curFrom > 0) {
+      return this.nextMatch(state, 0, curFrom) // try again from the start of the doc
+    }
+
     return cursor.done ? null : cursor.value
   }
 
   // Searching in reverse is, rather than implementing inverted search
   // cursor, done by scanning chunk after chunk forward.
-  private prevMatchInRange(doc: Text, from: number, to: number) {
+  private prevMatchInRange(state: EditorState, from: number, to: number): SearchResult | null {
     for (let pos = to;;) {
       let start = Math.max(from, pos - FindPrev.ChunkSize - this.spec.unquoted.length)
-      let cursor = stringCursor(this.spec, doc, start, pos), range: SearchResult | null = null
-      while (!cursor.nextOverlapping().done) range = cursor.value
-      if (range) return range
+      let cursor = stringCursor(this.spec, state.doc, start, pos)
+      do {
+        cursor.nextOverlapping()
+      } while (!cursor.done && !isValidMatch(this.spec, state, cursor.value))
+      if (cursor.value) return cursor.value
       if (start == from) return null
       pos -= FindPrev.ChunkSize
     }
   }
 
-  prevMatch(doc: Text, curFrom: number, curTo: number) {
-    return this.prevMatchInRange(doc, 0, curFrom) ||
-      this.prevMatchInRange(doc, curTo, doc.length)
+  prevMatch(state: EditorState, curFrom: number, curTo: number) {
+    return this.prevMatchInRange(state, 0, curFrom) ||
+      this.prevMatchInRange(state, curTo, state.doc.length)
   }
 
   getReplacement(_result: SearchResult) { return this.spec.replace }
 
-  matchAll(doc: Text, limit: number) {
-    let cursor = stringCursor(this.spec, doc, 0, doc.length), ranges = []
-    while (!cursor.next().done) {
-      if (ranges.length >= limit) return null
-      ranges.push(cursor.value)
+  matchAll(state: EditorState, limit: number) {
+    let ranges = []
+    let cursor = stringCursor(this.spec, state.doc, 0, state.doc.length)
+    while(!cursor.next().done) {
+      if (isValidMatch(this.spec, state, cursor.value)) {
+        ranges.push(cursor.value)
+        if (ranges.length >= limit) return null
+      }
     }
     return ranges
   }
 
-  highlight(doc: Text, from: number, to: number, add: (from: number, to: number) => void) {
-    let cursor = stringCursor(this.spec, doc, Math.max(0, from - this.spec.unquoted.length),
-                              Math.min(to + this.spec.unquoted.length, doc.length))
-    while (!cursor.next().done) add(cursor.value.from, cursor.value.to)
+  highlight(state: EditorState, from: number, to: number, add: (from: number, to: number) => void) {
+    let cursor = stringCursor(this.spec, state.doc, Math.max(0, from - this.spec.unquoted.length),
+                              Math.min(to + this.spec.unquoted.length, state.doc.length))
+    while (!cursor.next().done) {
+      if (isValidMatch(this.spec, state, cursor.value)) {
+        add(cursor.value.from, cursor.value.to)
+      }
+    }
   }
 }
 
@@ -195,25 +238,32 @@ function regexpCursor(spec: SearchQuery, doc: Text, from: number, to: number) {
 }
 
 class RegExpQuery extends QueryType<RegExpResult> {
-  nextMatch(doc: Text, curFrom: number, curTo: number) {
-    let cursor = regexpCursor(this.spec, doc, curTo, doc.length).next()
-    if (cursor.done) cursor = regexpCursor(this.spec, doc, 0, curFrom).next()
+  nextMatch(state: EditorState, curFrom: number, curTo: number): RegExpResult | null {
+    let cursor = regexpCursor(this.spec, state.doc, curTo, state.doc.length)
+    do {
+      cursor.next()
+    } while (!cursor.done && !isValidMatch(this.spec, state, cursor.value))
+    if (cursor.done && curFrom > 0) {
+      return this.nextMatch(state, 0, curFrom) // try again from the start of the doc
+    }
     return cursor.done ? null : cursor.value
   }
 
-  private prevMatchInRange(doc: Text, from: number, to: number) {
+  private prevMatchInRange(state: EditorState, from: number, to: number) {
     for (let size = 1;; size++) {
       let start = Math.max(from, to - size * FindPrev.ChunkSize)
-      let cursor = regexpCursor(this.spec, doc, start, to), range: RegExpResult | null = null
-      while (!cursor.next().done) range = cursor.value
-      if (range && (start == from || range.from > start + 10)) return range
+      let cursor = regexpCursor(this.spec, state.doc, start, to)
+      do {
+        cursor.next()
+      } while (!cursor.done && !isValidMatch(this.spec, state, cursor.value))
+      if (cursor.value && (start == from || cursor.value.from > start + 10)) return cursor.value
       if (start == from) return null
     }
   }
 
-  prevMatch(doc: Text, curFrom: number, curTo: number) {
-    return this.prevMatchInRange(doc, 0, curFrom) ||
-      this.prevMatchInRange(doc, curTo, doc.length)
+  prevMatch(state: EditorState, curFrom: number, curTo: number) {
+    return this.prevMatchInRange(state, 0, curFrom) ||
+      this.prevMatchInRange(state, curTo, state.doc.length)
   }
 
   getReplacement(result: RegExpResult) {
@@ -224,19 +274,26 @@ class RegExpQuery extends QueryType<RegExpResult> {
       : m)
   }
 
-  matchAll(doc: Text, limit: number) {
-    let cursor = regexpCursor(this.spec, doc, 0, doc.length), ranges = []
+  matchAll(state: EditorState, limit: number) {
+    let ranges = []
+    let cursor = regexpCursor(this.spec, state.doc, 0, state.doc.length)
     while (!cursor.next().done) {
-      if (ranges.length >= limit) return null
-      ranges.push(cursor.value)
+      if (isValidMatch(this.spec, state, cursor.value)) {
+        ranges.push(cursor.value)
+        if (ranges.length >= limit) return null
+      }
     }
     return ranges
   }
 
-  highlight(doc: Text, from: number, to: number, add: (from: number, to: number) => void) {
-    let cursor = regexpCursor(this.spec, doc, Math.max(0, from - RegExp.HighlightMargin),
-                              Math.min(to + RegExp.HighlightMargin, doc.length))
-    while (!cursor.next().done) add(cursor.value.from, cursor.value.to)
+  highlight(state: EditorState, from: number, to: number, add: (from: number, to: number) => void) {
+    let cursor = regexpCursor(this.spec, state.doc, Math.max(0, from - RegExp.HighlightMargin),
+                              Math.min(to + RegExp.HighlightMargin, state.doc.length))
+    while (!cursor.next().done) {
+      if (isValidMatch(this.spec, state, cursor.value)) {
+        add(cursor.value.from, cursor.value.to)
+      }
+    }
   }
 }
 
@@ -296,7 +353,7 @@ const searchHighlighter = ViewPlugin.fromClass(class {
     for (let i = 0, ranges = view.visibleRanges, l = ranges.length; i < l; i++) {
       let {from, to} = ranges[i]
       while (i < l - 1 && to > ranges[i + 1].from - 2 * RegExp.HighlightMargin) to = ranges[++i].to
-      query.highlight(view.state.doc, from, to, (from, to) => {
+      query.highlight(view.state, from, to, (from, to) => {
         let selected = view.state.selection.ranges.some(r => r.from == from && r.to == to)
         builder.add(from, to, selected ? selectedMatchMark : matchMark)
       })
@@ -320,7 +377,7 @@ function searchCommand(f: (view: EditorView, state: SearchState) => boolean): Co
 /// end.
 export const findNext = searchCommand((view, {query}) => {
   let {to} = view.state.selection.main
-  let next = query.nextMatch(view.state.doc, to, to)
+  let next = query.nextMatch(view.state, to, to)
   if (!next) return false
   view.dispatch({
     selection: {anchor: next.from, head: next.to},
@@ -336,7 +393,7 @@ export const findNext = searchCommand((view, {query}) => {
 /// of the document to start searching at the end again.
 export const findPrevious = searchCommand((view, {query}) => {
   let {state} = view, {from} = state.selection.main
-  let range = query.prevMatch(state.doc, from, from)
+  let range = query.prevMatch(state, from, from)
   if (!range) return false
   view.dispatch({
     selection: {anchor: range.from, head: range.to},
@@ -349,7 +406,7 @@ export const findPrevious = searchCommand((view, {query}) => {
 
 /// Select all instances of the search query.
 export const selectMatches = searchCommand((view, {query}) => {
-  let ranges = query.matchAll(view.state.doc, 1000)
+  let ranges = query.matchAll(view.state, 1000)
   if (!ranges || !ranges.length) return false
   view.dispatch({
     selection: EditorSelection.create(ranges.map(r => EditorSelection.range(r.from, r.to))),
@@ -380,14 +437,14 @@ export const selectSelectionMatches: StateCommand = ({state, dispatch}) => {
 export const replaceNext = searchCommand((view, {query}) => {
   let {state} = view, {from, to} = state.selection.main
   if (state.readOnly) return false
-  let next = query.nextMatch(state.doc, from, from)
+  let next = query.nextMatch(state, from, from)
   if (!next) return false
   let changes = [], selection: {anchor: number, head: number} | undefined, replacement: Text | undefined
   let announce = []
   if (next.from == from && next.to == to) {
     replacement = state.toText(query.getReplacement(next))
     changes.push({from: next.from, to: next.to, insert: replacement})
-    next = query.nextMatch(state.doc, next.from, next.to)
+    next = query.nextMatch(state, next.from, next.to)
     announce.push(EditorView.announce.of(
       state.phrase("replaced match on line $", state.doc.lineAt(from).number) + "."))
   }
@@ -409,7 +466,7 @@ export const replaceNext = searchCommand((view, {query}) => {
 /// replacement.
 export const replaceAll = searchCommand((view, {query}) => {
   if (view.state.readOnly) return false
-  let changes = query.matchAll(view.state.doc, 1e9)!.map(match => {
+  let changes = query.matchAll(view.state, 1e9)!.map(match => {
     let {from, to} = match
     return {from, to, insert: query.getReplacement(match)}
   })
@@ -430,8 +487,15 @@ function createSearchPanel(view: EditorView) {
 function defaultQuery(state: EditorState, fallback?: SearchQuery) {
   let sel = state.selection.main
   let selText = sel.empty || sel.to > sel.from + 100 ? "" : state.sliceDoc(sel.from, sel.to)
-  let caseSensitive = fallback?.caseSensitive ?? state.facet(searchConfigFacet).caseSensitive
-  return fallback && !selText ? fallback : new SearchQuery({search: selText.replace(/\n/g, "\\n"), caseSensitive})
+  if (fallback && !selText) {
+      return fallback
+  }
+  let config = state.facet(searchConfigFacet)
+  return new SearchQuery({
+    search: selText.replace(/\n/g, "\\n"),
+    caseSensitive: fallback?.caseSensitive ?? config.caseSensitive,
+    wholeWord: fallback?.wholeWord ?? config.wholeWord,
+  })
 }
 
 /// Make sure the search panel is open and focused.

--- a/src/word.ts
+++ b/src/word.ts
@@ -1,0 +1,19 @@
+import {CharCategory, EditorState} from "@codemirror/state";
+
+// Whether the characters directly outside the given positions are non-word characters
+export function insideWordBoundaries (check: (char: string) => CharCategory, state: EditorState, from: number, to: number): boolean {
+    return (from == 0 || check(state.sliceDoc(from - 1, from)) != CharCategory.Word) &&
+        (to == state.doc.length || check(state.sliceDoc(to, to + 1)) != CharCategory.Word)
+}
+
+// Whether the characters directly at the given positions are word characters
+export function insideWord (check: (char: string) => CharCategory, state: EditorState, from: number, to: number): boolean {
+    return check(state.sliceDoc(from, from + 1)) == CharCategory.Word
+        && check(state.sliceDoc(to - 1, to)) == CharCategory.Word
+}
+
+/// Whether the characters at the end of the given range are word characters inside non-word characters
+export function isWholeWord (check: (char: string) => CharCategory, state: EditorState, from: number, to: number): boolean {
+    return insideWordBoundaries(check, state, from, to)
+        && insideWord(check, state, from, to)
+}


### PR DESCRIPTION
It would be useful to have a "whole word" option for searches. This is particularly useful when replacing, to ensure that parts of words aren't unintentionally replaced.

* Refactor `insideWord` and `insideWordBoundaries` to a separate module, wrapped in `isWholeWord`.
* Add `wholeWord` boolean option to the `search` extension and the `SearchQuery` class.
* Add `isValidMatch` function, used to filter matches (currently only using the `wholeWord` option, but could potentially also be used for a "search within selection" option).
  * Pass `state` around instead of `doc`, so the state can be used inside the `isValidMatch` function.

This approach seems to work, but it does require creating `state.charCategorizer` for every match. It's an opt-in behaviour, so maybe that's acceptable, but I'm completely open to other ways of doing this.