### PR TITLE
Export togglePanel state effect

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -244,7 +244,8 @@ class RegExpQuery extends QueryType<RegExpResult> {
 /// once).
 export const setSearchQuery = StateEffect.define<SearchQuery>()
 
-const togglePanel = StateEffect.define<boolean>()
+/// A state effect that opens or closes the search panel
+export const togglePanel = StateEffect.define<boolean>()
 
 const searchState: StateField<SearchState> = StateField.define<SearchState>({
   create(state) {


### PR DESCRIPTION
We have an extension that's responsible for automatically highlighting matches when the search query changes, by watching for the `setSearchQuery` effect.

When the search panel was open, this should scroll the match into view, but when the search panel wasn't open (i.e. it's opening now), the match should not be scrolled into view.

To achieve this, we need to check the `togglePanel` effect for a value of `true` (i.e. the panel is opening), which means the `togglePanel` effect needs to be exported from the `@codemirror/search` package.

We don't intend to dispatch the `togglePanel` effect, as `closeSearchPanel` and `openSearchPanel` already exist for that purpose, so if you'd prefer to add a function that encapsulates `togglePanel` instead of exporting it, that would be fine too.