### PR TITLE
Prevent search inputs to partecipate to wrapper form

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -576,6 +576,7 @@ class SearchPanel implements Panel {
       "aria-label": phrase(view, "Find"),
       class: "cm-textfield",
       name: "search",
+      form: "",
       "main-field": "true",
       onchange: this.commit,
       onkeyup: this.commit
@@ -586,24 +587,28 @@ class SearchPanel implements Panel {
       "aria-label": phrase(view, "Replace"),
       class: "cm-textfield",
       name: "replace",
+      form: "",
       onchange: this.commit,
       onkeyup: this.commit
     }) as HTMLInputElement
     this.caseField = elt("input", {
       type: "checkbox",
       name: "case",
+      form: "",
       checked: query.caseSensitive,
       onchange: this.commit
     }) as HTMLInputElement
     this.reField = elt("input", {
       type: "checkbox",
       name: "re",
+      form: "",
       checked: query.regexp,
       onchange: this.commit
     }) as HTMLInputElement
     this.wordField = elt("input", {
       type: "checkbox",
       name: "word",
+      form: "",
       checked: query.wholeWord,
       onchange: this.commit
     }) as HTMLInputElement


### PR DESCRIPTION
When codemirror is used to edit a field that is part of a form, activating the search functionality will make panel inputs to partecipate to the form. This can lead to problems when the form uses security checks such as CSRF tokens and only certain fields are allowed. In some borderline cases, when there are other inputs with `name="search"` or `name="replace"` it might override the values previously entered.

Setting the `form=""`, those input will be ignored by form submission.