### PR TITLE
Put go-to position at center of view

### DIFF
--- a/src/goto-line.ts
+++ b/src/goto-line.ts
@@ -38,10 +38,10 @@ function createLineDialog(view: EditorView): Panel {
       line = line * (sign == "-" ? -1 : 1) + startLine.number
     }
     let docLine = state.doc.line(Math.max(1, Math.min(state.doc.lines, line)))
+    let selection = EditorSelection.cursor(docLine.from + Math.max(0, Math.min(col, docLine.length)))
     view.dispatch({
-      effects: dialogEffect.of(false),
-      selection: EditorSelection.cursor(docLine.from + Math.max(0, Math.min(col, docLine.length))),
-      scrollIntoView: true
+      effects: [dialogEffect.of(false), EditorView.scrollIntoView(selection.from, {y: 'center'})],
+      selection,
     })
     view.focus()
   }


### PR DESCRIPTION
Mimics vscode behavior and puts the line at the center of the view vertically, rather than moving the minimal amount to put the line on screen, which can result in the line being in various places (very top, very bottom). We've gotten feedback this is confusing for users.